### PR TITLE
Minor changes to getting started doc

### DIFF
--- a/docs/getting-started.qmd
+++ b/docs/getting-started.qmd
@@ -33,8 +33,8 @@ classification_task.add_example(Example(text="I got my package", label="Not Urge
 5. Choose an LLM Provider template
 ```{python}
 #| eval: false
-from prompt_learner.templates import markdown_template
-markdown_template = markdown_template.MarkdownTemplate(task=classification_task)
+from prompt_learner.templates import markdown
+markdown_template = markdown.MarkdownTemplate(task=classification_task)
 ```
 6. Run any Optimizer to sample Examples for inserting in prompt
 ```{python}
@@ -54,7 +54,7 @@ gpt_prompt.assemble_prompt()
 8. View your prompt!
 ```{python}
 #| eval: false
-gpt_prompt.prompt
+print(gpt_prompt.prompt)
 ```
 9. Evaluate performance of your prompt.
 ```{python}


### PR DESCRIPTION
I observed a minor bug when trying to execute the getting started script from the documentation. The markdown_template module was no longer available. I looked at the latest code and made the changes to the getting started script.
<img width="647" alt="Screenshot 2024-06-03 at 1 49 57 AM" src="https://github.com/attuna-xyz/prompt-learner/assets/39693265/4e6cf465-d011-4e2e-a069-6296ac92ea2c">
